### PR TITLE
chore: update python dependencies + pin pip

### DIFF
--- a/requirements-fmt.txt
+++ b/requirements-fmt.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.12.1
+black==24.8.0
     # via -r requirements-fmt.in
 click==8.1.7
     # via black
@@ -12,13 +12,13 @@ isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.2
+packaging==24.2
     # via black
 pathspec==0.12.1
     # via black
-platformdirs==4.1.0
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via black

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -4,35 +4,35 @@
 #
 #    pip-compile requirements-integration.in
 #
-anyio==4.2.0
+anyio==4.5.2
     # via httpx
-appnope==0.1.4
-    # via ipython
-asttokens==2.4.1
+asttokens==3.0.0
     # via stack-data
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
 backcall==0.2.0
     # via ipython
-bcrypt==4.1.2
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
     # via paramiko
-cachetools==5.3.2
+cachetools==5.5.0
     # via google-auth
-certifi==2023.11.17
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.2.1
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements-integration.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cryptography==41.0.7
+cryptography==44.0.0
     # via paramiko
 decorator==5.1.1
     # via
@@ -40,28 +40,28 @@ decorator==5.1.1
     #   ipython
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
-executing==2.0.1
+executing==2.1.0
     # via stack-data
-google-auth==2.26.1
+google-auth==2.36.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.2
+httpcore==1.0.7
     # via httpx
-httpx==0.26.0
+httpx==0.28.0
     # via lightkube
-hvac==2.1.0
+hvac==2.3.0
     # via juju
-idna==3.6
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.1.1
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
@@ -69,31 +69,32 @@ ipdb==0.13.13
     # via pytest-operator
 ipython==8.12.3
     # via ipdb
-jedi==0.19.1
+jedi==0.19.2
     # via ipython
-jinja2==3.1.2
+jinja2==3.1.4
     # via
     #   charmed-kubeflow-chisme
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==3.3.0.0
-    # via
-    #   -r requirements-integration.in
-    #   pytest-operator
-kubernetes==29.0.0
-    # via juju
-lightkube==0.15.0
+juju==3.6.0.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.29.0.6
+    #   pytest-operator
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.5
+    # via
+    #   -r requirements-integration.in
+    #   charmed-kubeflow-chisme
+lightkube-models==1.31.1.8
     # via lightkube
 macaroonbakery==1.3.4
     # via juju
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
     # via typing-inspect
@@ -101,17 +102,19 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.14.0
+ops==2.17.1
     # via
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==23.2
-    # via pytest
-paramiko==2.12.0
+packaging==24.2
+    # via
+    #   juju
+    #   pytest
+paramiko==3.5.0
     # via juju
-parso==0.8.3
+parso==0.8.4
     # via jedi
 pexpect==4.9.0
     # via ipython
@@ -119,26 +122,26 @@ pickleshare==0.7.5
     # via ipython
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.48
     # via ipython
-protobuf==4.25.1
+protobuf==5.29.0
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
-pyasn1==0.5.1
+pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.1
     # via google-auth
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pygments==2.17.2
+pygments==2.18.0
     # via ipython
 pymacaroons==0.13.0
     # via macaroonbakery
@@ -153,19 +156,19 @@ pyrfc3339==1.1
     #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pytest==7.4.4
+pytest==8.3.4
     # via
     #   pytest-asyncio
     #   pytest-operator
-pytest-asyncio==0.21.1
+pytest-asyncio==0.21.2
     # via pytest-operator
-pytest-operator==0.31.1
+pytest-operator==0.38.0
     # via -r requirements-integration.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2023.3.post1
+pytz==2024.2
     # via pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   juju
     #   kubernetes
@@ -173,18 +176,18 @@ pyyaml==6.0.1
     #   ops
     #   pytest-operator
     #   serialized-data-interface
-requests==2.31.0
+requests==2.32.3
     # via
     #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
     #   serialized-data-interface
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruamel-yaml==0.18.5
+ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
@@ -192,48 +195,45 @@ serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
 six==1.16.0
     # via
-    #   asttokens
     #   kubernetes
     #   macaroonbakery
-    #   paramiko
     #   pymacaroons
     #   python-dateutil
-sniffio==1.3.0
-    # via
-    #   anyio
-    #   httpx
+sniffio==1.3.1
+    # via anyio
 stack-data==0.6.3
     # via ipython
-tenacity==8.2.3
+tenacity==9.0.0
     # via charmed-kubeflow-chisme
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   ipdb
     #   pytest
 toposort==1.10
     # via juju
-traitlets==5.14.1
+traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via
     #   anyio
     #   ipython
+    #   juju
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==2.1.0
+urllib3==2.2.3
     # via
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via
     #   kubernetes
     #   ops
-websockets==8.1
+websockets==13.1
     # via juju
-zipp==3.17.0
+zipp==3.20.2
     # via importlib-resources

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,19 +4,19 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.12.1
+black==24.8.0
     # via -r requirements-lint.in
 click==8.1.7
     # via black
-codespell==2.2.6
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.1.0
+flake8==7.0.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.2.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
@@ -26,25 +26,25 @@ mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.2
+packaging==24.2
     # via black
 pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==4.1.0
+platformdirs==4.3.6
     # via black
 pycodestyle==2.11.1
     # via flake8
-pyflakes==3.1.0
+pyflakes==3.2.0
     # via flake8
-pyproject-flake8==6.1.0
+pyproject-flake8==7.0.0
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -4,56 +4,86 @@
 #
 #    pip-compile requirements-unit.in
 #
-anyio==4.2.0
+anyio==4.5.2
     # via
     #   -r requirements.txt
     #   httpx
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -r requirements.txt
     #   jsonschema
-certifi==2023.11.17
+backports-strenum==1.3.1
+    # via
+    #   -r requirements.txt
+    #   juju
+bcrypt==4.2.1
+    # via
+    #   -r requirements.txt
+    #   paramiko
+cachetools==5.5.0
+    # via
+    #   -r requirements.txt
+    #   google-auth
+certifi==2024.8.30
     # via
     #   -r requirements.txt
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.1
+cffi==1.17.1
+    # via
+    #   -r requirements.txt
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.txt
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via
     #   -r requirements.txt
     #   requests
-coverage==7.4.0
+coverage==7.6.1
     # via -r requirements-unit.in
+cryptography==44.0.0
+    # via
+    #   -r requirements.txt
+    #   paramiko
 deepdiff==6.2.1
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via
     #   -r requirements.txt
     #   anyio
     #   pytest
+google-auth==2.36.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
 h11==0.14.0
     # via
     #   -r requirements.txt
     #   httpcore
-httpcore==1.0.2
+httpcore==1.0.7
     # via
     #   -r requirements.txt
     #   httpx
-httpx==0.26.0
+httpx==0.28.0
     # via
     #   -r requirements.txt
     #   lightkube
-idna==3.6
+hvac==2.3.0
+    # via
+    #   -r requirements.txt
+    #   juju
+idna==3.10
     # via
     #   -r requirements.txt
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.1.1
+importlib-resources==6.4.5
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -67,19 +97,40 @@ jsonschema==4.17.3
     # via
     #   -r requirements.txt
     #   serialized-data-interface
-lightkube==0.15.0
+juju==3.6.0.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-lightkube-models==1.29.0.6
+kubernetes==30.1.0
+    # via
+    #   -r requirements.txt
+    #   juju
+lightkube==0.15.5
+    # via
+    #   -r requirements.txt
+    #   charmed-kubeflow-chisme
+lightkube-models==1.31.1.8
     # via
     #   -r requirements.txt
     #   lightkube
-markupsafe==2.1.4
+macaroonbakery==1.3.4
+    # via
+    #   -r requirements.txt
+    #   juju
+markupsafe==2.1.5
     # via
     #   -r requirements.txt
     #   jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via
+    #   -r requirements.txt
+    #   typing-inspect
+oauthlib==3.2.2
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.17.1
     # via
     #   -r requirements-unit.in
     #   -r requirements.txt
@@ -89,39 +140,101 @@ ordered-set==4.1.0
     # via
     #   -r requirements.txt
     #   deepdiff
-packaging==23.2
-    # via pytest
+packaging==24.2
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   pytest
+paramiko==3.5.0
+    # via
+    #   -r requirements.txt
+    #   juju
 pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements.txt
     #   jsonschema
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
+protobuf==5.29.0
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via
+    #   -r requirements.txt
+    #   google-auth
+pycparser==2.22
+    # via
+    #   -r requirements.txt
+    #   cffi
+pymacaroons==0.13.0
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+pynacl==1.5.0
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   macaroonbakery
 pyrsistent==0.20.0
     # via
     #   -r requirements.txt
     #   jsonschema
-pytest==7.4.4
+pytest==8.3.4
     # via
     #   -r requirements-unit.in
     #   pytest-lazy-fixture
     #   pytest-mock
 pytest-lazy-fixture==0.6.3
     # via -r requirements-unit.in
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via -r requirements-unit.in
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+pytz==2024.2
+    # via
+    #   -r requirements.txt
+    #   pyrfc3339
+pyyaml==6.0.2
     # via
     #   -r requirements-unit.in
     #   -r requirements.txt
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
+requests==2.32.3
     # via
     #   -r requirements.txt
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
     #   serialized-data-interface
-ruamel-yaml==0.18.5
+requests-oauthlib==2.0.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+rsa==4.9
+    # via
+    #   -r requirements.txt
+    #   google-auth
+ruamel-yaml==0.18.6
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
@@ -133,30 +246,52 @@ serialized-data-interface==0.7.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
     # via
     #   -r requirements.txt
     #   anyio
-    #   httpx
-tenacity==8.2.3
+tenacity==9.0.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-tomli==2.0.1
+tomli==2.2.1
     # via pytest
-typing-extensions==4.9.0
+toposort==1.10
+    # via
+    #   -r requirements.txt
+    #   juju
+typing-extensions==4.12.2
     # via
     #   -r requirements.txt
     #   anyio
-urllib3==2.1.0
+    #   juju
+    #   typing-inspect
+typing-inspect==0.9.0
     # via
     #   -r requirements.txt
+    #   juju
+urllib3==2.2.3
+    # via
+    #   -r requirements.txt
+    #   kubernetes
     #   requests
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via
     #   -r requirements.txt
+    #   kubernetes
     #   ops
-zipp==3.17.0
+websockets==13.1
+    # via
+    #   -r requirements.txt
+    #   juju
+zipp==3.20.2
     # via
     #   -r requirements.txt
     #   importlib-resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,82 +4,169 @@
 #
 #    pip-compile requirements.in
 #
-anyio==4.2.0
+anyio==4.5.2
     # via httpx
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
-certifi==2023.11.17
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
+    # via paramiko
+cachetools==5.5.0
+    # via google-auth
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.1
+cffi==1.17.1
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
+cryptography==44.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via anyio
+google-auth==2.36.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.2
+httpcore==1.0.7
     # via httpx
-httpx==0.26.0
+httpx==0.28.0
     # via lightkube
-idna==3.6
+hvac==2.3.0
+    # via juju
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.1.1
+importlib-resources==6.4.5
     # via jsonschema
 jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.15.0
+juju==3.6.0.0
     # via charmed-kubeflow-chisme
-lightkube-models==1.29.0.6
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.5
+    # via charmed-kubeflow-chisme
+lightkube-models==1.31.1.8
     # via lightkube
-markupsafe==2.1.4
+macaroonbakery==1.3.4
+    # via juju
+markupsafe==2.1.5
     # via jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.17.1
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
+packaging==24.2
+    # via juju
+paramiko==3.5.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
+protobuf==5.29.0
+    # via macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
+pycparser==2.22
+    # via cffi
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.2
+    # via pyrfc3339
+pyyaml==6.0.2
     # via
     #   -r requirements.in
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
-ruamel-yaml==0.18.5
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
+ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
+    # via
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
+    # via anyio
+tenacity==9.0.0
+    # via charmed-kubeflow-chisme
+toposort==1.10
+    # via juju
+typing-extensions==4.12.2
     # via
     #   anyio
-    #   httpx
-tenacity==8.2.3
-    # via charmed-kubeflow-chisme
-typing-extensions==4.9.0
-    # via anyio
-urllib3==2.1.0
-    # via requests
-websocket-client==1.7.0
-    # via ops
-zipp==3.17.0
+    #   juju
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.3
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==13.1
+    # via juju
+zipp==3.20.2
     # via importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]


### PR DESCRIPTION
* Pin pip to 24.2 due to https://github.com/jazzband/pip-tools/issues/2131
* Update python dependencies using 'tox -e update-requirements'

Ref canonical/bundle-kubeflow#1177