### PR TITLE
feat: Add GitHub files for issues templates and Jira automation

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,31 @@
+settings:
+    # Jira project key to create the issue in
+  jira_project_key: "KF"
+
+  # Dictionary mapping GitHub issue status to Jira issue status
+  status_mapping:
+    opened: Untriaged
+    closed: done
+
+  # (Optional) GitHub labels. Only issues with one of those labels will be synchronized.
+  # If not specified, all issues will be synchronized
+  labels:
+    - bug
+    - enhancement
+
+  # (Optional) (Default: false) Add a new comment in GitHub with a link to Jira created issue
+  add_gh_comment: true
+
+  # (Optional) (Default: true) Synchronize issue description from GitHub to Jira
+  sync_description: true
+
+  # (Optional) (Default: true) Synchronize comments from GitHub to Jira
+  sync_comments: false
+
+  # (Optional) (Default: None) Parent Epic key to link the issue to
+  epic_key: "KF-4805"
+
+  # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
+  # If label on the issue is not in specified list, this issue will be created as a Bug
+  label_mapping:
+    enhancement: Story

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: File a bug report
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
+        sure you are using the latest version of the charms. If not, please switch to the newest revision prior to
+        posting your report to make sure it's not already solved.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: >
+        If applicable, add screenshots to help explain your problem. If applicable, add screenshots to
+        help explain the problem you are facing.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: >
+        Please provide a step-by-step instruction of how to reproduce the behavior.
+      placeholder: |
+        1. `juju deploy ...`
+        2. `juju relate ...`
+        3. `juju status --relations`
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        We need to know a bit more about the context in which you run the charm.
+        - Are you running Juju locally, on lxd, in multipass or on some other platform?
+        - What track and channel you deployed the charm from (ie. `latest/edge` or similar).
+        - Version of any applicable components, like the juju snap, the model controller, lxd, microk8s, and/or multipass.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: >
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs
+        at https://juju.is/docs/olm/juju-logs
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -1,0 +1,44 @@
+name: Task
+description: File an enhancement proposal
+labels: "enhancement"
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this enhancement
+        proposal! Before submitting your issue, please make sure there
+        isn't already a prior issue concerning this. If there is,
+        please join that discussion instead.
+  - type: textarea
+    id: enhancement-proposal-context
+    attributes:
+      label: Context
+      description: >
+        Describe why we should work on this task/enhancement, as well as
+        existing context we should be aware of
+    validations:
+      required: true
+  - type: textarea
+    id: enhancement-proposal-what
+    attributes:
+      label: What needs to get done
+      description: >
+        Describe what needs to get done
+      placeholder: |
+        1. Look into X
+        2. Implement Y
+        3. Create file Z
+    validations:
+      required: true
+  - type: textarea
+    id: enhancement-proposal-dod
+    attributes:
+      label: Definition of Done
+      description: >
+        What are the requirements for the task to be considered done
+      placeholder: |
+        1. We know how X works (spike)
+        2. Code is doing Y
+        3. Charm has functionality Z
+    validations:
+      required: true


### PR DESCRIPTION
Closes #35

This PR adds:
- Issues templates under `.github/ISSUE_TEMPLATE`
- Jira automation